### PR TITLE
Adjusting for postmates usage

### DIFF
--- a/mkwheelhouse.py
+++ b/mkwheelhouse.py
@@ -51,7 +51,7 @@ class Bucket(object):
         stdout, _ = process.communicate()
         location = json.loads(stdout.decode())['LocationConstraint']
         if not location:
-            return 'us-east-1'
+            return 'us-west-1'
         elif location == 'EU':
             return 'eu-west-1'
         else:
@@ -68,7 +68,9 @@ class Bucket(object):
 
     def generate_url(self, key):
         key = self.get_key(key)
-        return key.generate_url(expires_in=0, query_auth=False)
+        url = key.generate_url(expires_in=0, query_auth=False)
+        # Temporary hack for fixing the links
+        return url.replace('https', 'http').split('?')[0]
 
     def list(self):
         return self.bucket.list(prefix=self.prefix)

--- a/mkwheelhouse.py
+++ b/mkwheelhouse.py
@@ -106,7 +106,8 @@ def build_wheels(packages, index_url, requirements, exclusions):
     temp_dir = tempfile.mkdtemp(prefix='mkwheelhouse-')
 
     args = [
-        'pip', 'wheel',
+        os.environ['VIRTUAL_ENV'] + '/bin/pip',
+        'wheel',
         '--wheel-dir', temp_dir,
         '--find-links', index_url,
         # pip < 7 doesn't invalidate HTTP cache based on last-modified

--- a/mkwheelhouse.py
+++ b/mkwheelhouse.py
@@ -108,8 +108,7 @@ def build_wheels(packages, index_url, requirements, exclusions):
     temp_dir = tempfile.mkdtemp(prefix='mkwheelhouse-')
 
     args = [
-        os.environ['VIRTUAL_ENV'] + '/bin/pip',
-        'wheel',
+        'pip', 'wheel',
         '--wheel-dir', temp_dir,
         '--find-links', index_url,
         # pip < 7 doesn't invalidate HTTP cache based on last-modified


### PR DESCRIPTION
- Use us-west-1 by default for now.
- Make URLs from inside `index.html` work. Our S3 bucket is available from inside the VPC, so there's no need in ACL or even HTTPS.
